### PR TITLE
fixing permission issues for

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,6 +18,11 @@ COPY . .
 # Create logs directory for PM2
 RUN mkdir -p logs
 
+# Fix all permission issues
+RUN chmod +x node_modules/.bin/* && \
+    chmod -R 755 /app && \
+    npm cache clean --force
+
 # Build the application
 RUN npm run build
 


### PR DESCRIPTION
```
 => ERROR [frontend 8/8] RUN npm run build                                                                                                                                                                                            0.5s
------
 > [frontend 8/8] RUN npm run build:
0.401
0.401 > frontend@0.1.0 build
0.401 > react-scripts build
0.401
0.405 sh: react-scripts: Permission denied
------
failed to solve: process "/bin/sh -c npm run build" did not complete successfully: exit code: 126

````