### PR TITLE
gem_monitoring-frontend-1 | 2025-06-24T05:07:35: Node.js v18.20.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     env_file:
       - .env
     environment:
+      - BROWSER=none
       - REACT_APP_API_URL=http://localhost:8001/service
       - PORT=3000
       - HOST=0.0.0.0


### PR DESCRIPTION
gem_monitoring-frontend-1 | 2025-06-24T05:07:36: PM2 log: App [react-app:0] exited with code [1] via signal [SIGINT] gem_monitoring-frontend-1 | 2025-06-24T05:07:36: PM2 log: App [react-app:0] starting in -fork mode- gem_monitoring-frontend-1 | 2025-06-24T05:07:36: PM2 log: App [react-app:0] online gem_monitoring-frontend-1 | 2025-06-24T05:07:36: Attempting to bind to HOST environment variable: 0.0.0.0 gem_monitoring-frontend-1 | 2025-06-24T05:07:36: If this was unintentional, check that you haven't mistakenly set it in your shell. gem_monitoring-frontend-1 | 2025-06-24T05:07:36: Learn more here: https://cra.link/advanced-config gem_monitoring-frontend-1 | 2025-06-24T05:07:36:
gem_monitoring-frontend-1 | 2025-06-24T05:07:37: (node:1308) [DEP_WEBPACK_DEV_SERVER_ON_AFTER_SETUP_MIDDLEWARE] DeprecationWarning: 'onAfterSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option. gem_monitoring-frontend-1 | 2025-06-24T05:07:37: (Use `node --trace-deprecation ...` to show where the warning was created) gem_monitoring-frontend-1 | 2025-06-24T05:07:37: (node:1308) [DEP_WEBPACK_DEV_SERVER_ON_BEFORE_SETUP_MIDDLEWARE] DeprecationWarning: 'onBeforeSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option. gem_monitoring-frontend-1 | 2025-06-24T05:07:37: Starting the development server... gem_monitoring-frontend-1 | 2025-06-24T05:07:37:
gem_monitoring-frontend-1 | 2025-06-24T05:07:37: node:events:495
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:       throw er; // Unhandled 'error' event
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:       ^
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:
gem_monitoring-frontend-1 | 2025-06-24T05:07:37: Error: spawn xdg-open ENOENT
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:     at ChildProcess._handle.onexit (node:internal/child_process:284:19)
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:     at onErrorNT (node:internal/child_process:477:16)
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:     at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
gem_monitoring-frontend-1 | 2025-06-24T05:07:37: Emitted 'error' event on ChildProcess instance at:
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:     at ChildProcess._handle.onexit (node:internal/child_process:290:12)
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:     at onErrorNT (node:internal/child_process:477:16)
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:     at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:   errno: -2,
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:   code: 'ENOENT',
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:   syscall: 'spawn xdg-open',
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:   path: 'xdg-open',
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:   spawnargs: [ 'http://localhost:3000' ]
gem_monitoring-frontend-1 | 2025-06-24T05:07:37: }
gem_monitoring-frontend-1 | 2025-06-24T05:07:37:
gem_monitoring-frontend-1 | 2025-06-24T05:07:37: Node.js v18.20.8
gem_monitoring-frontend-1 | 2025-06-24T05:07:37: PM2 log: App [react-app:0] exited with code [1] via signal [SIGINT]
gem_monitoring-frontend-1 | 2025-06-24T05:07:37: PM2 log: App [react-app:0] starting in -fork mode-
gem_monitoring-frontend-1 | 2025-06-24T05:07:37: PM2 log: App [react-app:0] online